### PR TITLE
Fix for issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/rpm/pap/argus-pap.spec
+++ b/rpm/pap/argus-pap.spec
@@ -86,15 +86,22 @@ if [ $1 -gt 1 ] ; then
     fi
 fi
 
+%post
+if [ `pidof systemd` ]; then
+	/usr/bin/systemctl daemon-reload
+fi
+
 %preun
 if [ $1 -eq 0 ] ; then
     /sbin/service argus-pap stop > /dev/null 2>&1 || :
-    /sbin/chkconfig --del argus-pap
+	if [ ! `pidof systemd` ]; then
+    	/sbin/chkconfig --del argus-pap
+	fi
 fi
 
 
 # register the service in init.d
-if [ $1 -eq 1 ]; then
+if [ $1 -eq 1 && ! `pidof systemd` ]; then
     /sbin/chkconfig --add argus-pap
 fi
 

--- a/rpm/pap/argus-pap.spec
+++ b/rpm/pap/argus-pap.spec
@@ -107,7 +107,6 @@ fi
 %files
 
 %defattr(-,root,root,-)
-%{_initrddir}/argus-pap
 
 %dir %{_sysconfdir}/argus/pap
 
@@ -148,12 +147,17 @@ fi
 %dir %{_localstatedir}/log/argus/pap
 
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
+%exclude %{_initrddir}/argus-pap
 /lib/systemd/system/argus-pap.service
 %else
 %exclude /lib/systemd/system/argus-pap.service
+%{_initrddir}/argus-pap
 %endif
 
 %changelog
+* Mon Apr 11 2016 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-2
+- Exclude sysV init script for EL7.
+
 * Tue Nov 17 2015 Marco Caberletti <marco.caberletti at cnaf.infn.it> - 1.7.0-0
 - Support for Systemd
 

--- a/rpm/pap/argus-pap.spec
+++ b/rpm/pap/argus-pap.spec
@@ -42,7 +42,6 @@ BuildRequires: java-%{jdk_version}-openjdk-devel
 
 Requires: java-%{jdk_version}-openjdk
 Requires: canl-java
-Requires: bouncycastle-pkix
 
 %description
 Argus PAP (Policy Administration Point).

--- a/rpm/pap/argus-pap.spec
+++ b/rpm/pap/argus-pap.spec
@@ -41,7 +41,7 @@ BuildRequires: %{maven}
 BuildRequires: java-%{jdk_version}-openjdk-devel
 
 Requires: java-%{jdk_version}-openjdk
-Requires: canl-java
+Requires: voms-api-java
 
 %description
 Argus PAP (Policy Administration Point).

--- a/rpm/pdp/argus-pdp.spec
+++ b/rpm/pdp/argus-pdp.spec
@@ -48,25 +48,25 @@ Requires: voms-api-java
 
 %description
 Argus PDP (Policy Decision Point).
-The Argus Authorization Service renders consistent authorization 
-decisions for distributed services (e.g., user interfaces, 
-portals, computing elements, storage elements). The service is 
-based on the XACML standard, and uses authorization policies to 
-determine if a user is allowed or denied to perform a certain 
+The Argus Authorization Service renders consistent authorization
+decisions for distributed services (e.g., user interfaces,
+portals, computing elements, storage elements). The service is
+based on the XACML standard, and uses authorization policies to
+determine if a user is allowed or denied to perform a certain
 action on a particular service.
-The Argus Authorization Service is composed of three main 
+The Argus Authorization Service is composed of three main
 components:
-- The Policy Administration Point (PAP) provides the tools to 
-author authorization policies, organize them in the local 
+- The Policy Administration Point (PAP) provides the tools to
+author authorization policies, organize them in the local
 repository and configure policy distribution among remote PAPs.
-- The Policy Decision Point (PDP) implements the authorization 
+- The Policy Decision Point (PDP) implements the authorization
 engine, and is responsible for the evaluation of the authorization
 requests against the XACML policies retrieved from the PAP.
-- The Policy Enforcement Point Server (PEP Server) ensures the 
-integrity and consistency of the authorization requests received 
-from the PEP clients. Lightweight PEP client libraries are also 
-provided to ease the integration and interoperability with other 
-EMI services or components. 
+- The Policy Enforcement Point Server (PEP Server) ensures the
+integrity and consistency of the authorization requests received
+from the PEP clients. Lightweight PEP client libraries are also
+provided to ease the integration and interoperability with other
+EMI services or components.
 
 %prep
 %setup -q
@@ -86,14 +86,14 @@ rm -rf $RPM_BUILD_ROOT
 # on upgrade (2): stop the service, and clean up the lib directory
 if [ $1 -eq 2 ] ; then
     /sbin/service argus-pdp stop > /dev/null 2>&1 || :
-    # delete old jar 
+    # delete old jar
     find /var/lib/argus/pdp/lib -name "*.jar" -exec rm {} \;
 fi
 
 %post
 # on install (1): register the service in init.d
 # on upgrade (2): nothing
-if [ $1 -eq 1 ]; then 
+if [ $1 -eq 1 ]; then
     /sbin/chkconfig --add argus-pdp
 fi
 # correct files/dirs permission
@@ -111,14 +111,13 @@ fi
 
 %postun
 # on uninstall (0): nothing
-# on upgrade (1): restart the service 
+# on upgrade (1): restart the service
 if [ $1 -eq 1 ] ; then
     /sbin/service argus-pdp start
 fi
 
 %files
 %defattr(-,root,root,-)
-%{_sysconfdir}/init.d/argus-pdp
 %dir %{_sysconfdir}/argus/pdp
 %config(noreplace) %{_sysconfdir}/argus/pdp/logging.xml
 %config(noreplace) %{_sysconfdir}/argus/pdp/pdp.ini
@@ -179,12 +178,17 @@ fi
 %dir %{_localstatedir}/log/argus/pdp
 
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
+%exclude %{_sysconfdir}/init.d/argus-pdp
 /lib/systemd/system/argus-pdp.service
 %else
 %exclude /lib/systemd/system/argus-pdp.service
+%{_sysconfdir}/init.d/argus-pdp
 %endif
 
 %changelog
+* Mon Apr 11 2016 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-2
+- Exclude sysV init script for EL7.
+
 * Tue Nov 17 2015 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-1
 - Add systemd unit file.
 
@@ -195,7 +199,7 @@ fi
 - Replace exact versions, except argus-pdp, in filelist with wildcard.
 - Upstream version 1.6.1 for EMI-3.
 
-* Sun Nov 18 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1 
+* Sun Nov 18 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1
 - Upstream version 1.6.0 for EMI-3.
 
 * Mon Jul 30 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.5.2-1

--- a/rpm/pdp/argus-pdp.spec
+++ b/rpm/pdp/argus-pdp.spec
@@ -93,20 +93,25 @@ fi
 %post
 # on install (1): register the service in init.d
 # on upgrade (2): nothing
-if [ $1 -eq 1 ]; then
+if [ $1 -eq 1 ] && [ -z `pidof systemd` ] ; then
     /sbin/chkconfig --add argus-pdp
 fi
 # correct files/dirs permission
 chmod -f 640 %{_sysconfdir}/argus/pdp/pdp.ini
 chmod -f 750 %{_datadir}/argus/pdp/sbin/pdpctl
 chmod -f 750 %{_localstatedir}/log/argus/pdp
+if [ `pidof systemd` ]; then
+	/usr/bin/systemctl daemon-reload
+fi
 
 %preun
 # on uninstall (0): stop and deregister the service
 # on upgrade (1): nothing
 if [ $1 -eq 0 ] ; then
     /sbin/service argus-pdp stop > /dev/null 2>&1 || :
-    /sbin/chkconfig --del argus-pdp
+	if [ ! `pidof systemd` ]; then
+    	/sbin/chkconfig --del argus-pdp
+	fi
 fi
 
 %postun

--- a/rpm/pep-server/argus-pep-server.spec
+++ b/rpm/pep-server/argus-pep-server.spec
@@ -97,13 +97,17 @@ fi
 %post
 # on install (1): register the service in init.d
 # on upgrade (2): nothing
-if [ $1 -eq 1 ]; then
+if [ $1 -eq 1 ] && [ -z `pidof systemd` ] ; then
     /sbin/chkconfig --add argus-pepd
 fi
 # correct files/dirs permission
 chmod -f 640 %{_sysconfdir}/argus/pepd/pepd.ini
 chmod -f 750 %{_datadir}/argus/pepd/sbin/pepdctl
 chmod -f 750 %{_localstatedir}/log/argus/pepd
+if [ `pidof systemd` ]; then
+	/usr/bin/systemctl daemon-reload
+fi
+
 
 
 %preun
@@ -111,7 +115,9 @@ chmod -f 750 %{_localstatedir}/log/argus/pepd
 # on upgrade (1): nothing
 if [ $1 -eq 0 ] ; then
     /sbin/service argus-pepd stop > /dev/null 2>&1 || :
-    /sbin/chkconfig --del argus-pepd
+	if [ ! `pidof systemd` ]; then
+    	/sbin/chkconfig --del argus-pepd
+	fi
 fi
 
 %postun

--- a/rpm/pep-server/argus-pep-server.spec
+++ b/rpm/pep-server/argus-pep-server.spec
@@ -47,28 +47,28 @@ Requires: argus-pep-common >= 2.3
 Requires: argus-pdp-pep-common >= 1.5
 Requires: voms-api-java
 
-%description 
+%description
 Argus PEP (Policy Enforcement Point) Server.
-The Argus Authorization Service renders consistent authorization 
-decisions for distributed services (e.g., user interfaces, 
-portals, computing elements, storage elements). The service is 
-based on the XACML standard, and uses authorization policies to 
-determine if a user is allowed or denied to perform a certain 
+The Argus Authorization Service renders consistent authorization
+decisions for distributed services (e.g., user interfaces,
+portals, computing elements, storage elements). The service is
+based on the XACML standard, and uses authorization policies to
+determine if a user is allowed or denied to perform a certain
 action on a particular service.
 .
-The Argus Authorization Service is composed of three main 
+The Argus Authorization Service is composed of three main
 components:
-- The Policy Administration Point (PAP) provides the tools to 
-author authorization policies, organize them in the local 
+- The Policy Administration Point (PAP) provides the tools to
+author authorization policies, organize them in the local
 repository and configure policy distribution among remote PAPs.
-- The Policy Decision Point (PDP) implements the authorization 
+- The Policy Decision Point (PDP) implements the authorization
 engine, and is responsible for the evaluation of the authorization
 requests against the XACML policies retrieved from the PAP.
-- The Policy Enforcement Point Server (PEP Server) ensures the 
-integrity and consistency of the authorization requests received 
-from the PEP clients. Lightweight PEP client libraries are also 
-provided to ease the integration and interoperability with other 
-EMI services or components. 
+- The Policy Enforcement Point Server (PEP Server) ensures the
+integrity and consistency of the authorization requests received
+from the PEP clients. Lightweight PEP client libraries are also
+provided to ease the integration and interoperability with other
+EMI services or components.
 
 %prep
 %setup -q
@@ -89,7 +89,7 @@ rm -rf $RPM_BUILD_ROOT
 # on upgrade (2): stop the service, and clean up the lib directory
 if [ $1 -eq 2 ] ; then
     /sbin/service argus-pepd stop > /dev/null 2>&1 || :
-    # delete old jar 
+    # delete old jar
     find /var/lib/argus/pepd/lib -name "*.jar" -exec rm {} \;
 fi
 
@@ -97,7 +97,7 @@ fi
 %post
 # on install (1): register the service in init.d
 # on upgrade (2): nothing
-if [ $1 -eq 1 ]; then 
+if [ $1 -eq 1 ]; then
     /sbin/chkconfig --add argus-pepd
 fi
 # correct files/dirs permission
@@ -116,7 +116,7 @@ fi
 
 %postun
 # on uninstall (0): nothing
-# on upgrade (1): restart the service 
+# on upgrade (1): restart the service
 if [ $1 -eq 1 ] ; then
     /sbin/service argus-pepd start
 fi
@@ -124,7 +124,6 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%{_sysconfdir}/init.d/argus-pepd
 %dir %{_sysconfdir}/argus/pepd
 %config(noreplace) %{_sysconfdir}/argus/pepd/logging.xml
 %config(noreplace) %{_sysconfdir}/argus/pepd/pepd.ini
@@ -181,12 +180,17 @@ fi
 %dir %{_localstatedir}/log/argus/pepd
 
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
+%exclude %{_sysconfdir}/init.d/argus-pepd
 /lib/systemd/system/argus-pepd.service
 %else
 %exclude /lib/systemd/system/argus-pepd.service
+%{_sysconfdir}/init.d/argus-pepd
 %endif
 
 %changelog
+* Mon Apr 11 2016 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-2
+- Exclude sysV init script for EL7.
+
 * Tue Nov 17 2015 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-1
 - Add systemd unit file.
 
@@ -206,10 +210,10 @@ fi
 * Wed Jan 30 2013 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-3
 - Upstream version 1.6.0 for EMI-3 release.
 
-* Tue Jan 29 2013 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-2 
+* Tue Jan 29 2013 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-2
 - Upstream version 1.6.0 for EMI-3 (RC2).
 
-* Sun Nov 18 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1 
+* Sun Nov 18 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1
 - Upstream version 1.6.0 for EMI-3 (RC1).
 
 * Mon Jul 30 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.5.2-1


### PR DESCRIPTION
This fix exclude sysV init scripts for EL7-based operating systems.
Add some controls in pre and post-install, for execute some instructions only on EL6.
