### PR TITLE
Include Argus metapackage in build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 PLATFORM=${PLATFORM:-centos6}
-COMPONENTS=${COMPONENTS:-"pap pdp-pep-common pep-common pdp pep-server pep-api-c pep-api-java pepcli gsi-pep-callout"}
+COMPONENTS=${COMPONENTS:-"pap pdp-pep-common pep-common pdp pep-server pep-api-c pep-api-java pepcli gsi-pep-callout metapackage"}
 
 pkg_base_image_name="italiangrid/pkg.base:${PLATFORM}"
 

--- a/rpm/metapackage/argus-authz.spec
+++ b/rpm/metapackage/argus-authz.spec
@@ -1,0 +1,54 @@
+Name: argus-authz
+
+Version: @@SPEC_VERSION@@
+Release: @@SPEC_RELEASE@@%{?dist}
+Summary: Argus Authorization Service meta-package (PAP, PDP and PEP Server)
+
+Group: System Environment/Daemons
+License: ASL 2.0
+URL: https://twiki.cern.ch/twiki/bin/view/EGEE/AuthorizationFramework
+
+#Source:
+#BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch: noarch
+
+Requires: argus-pap
+Requires: argus-pdp
+Requires: argus-pep-server
+Requires: argus-pepcli
+Requires: bdii
+Requires: lcg-expiregridmapdir
+
+%description
+Argus meta-package (PAP, PDP and PEP Server).
+The Argus Authorization Service is composed of three main
+components:
+- The Policy Administration Point (PAP) provides the tools to
+author authorization policies, organize them in the local
+repository and configure policy distribution among remote PAPs.
+- The Policy Decision Point (PDP) implements the authorization
+engine, and is responsible for the evaluation of the authorization
+requests against the XACML policies retrieved from the PAP.
+- The Policy Enforcement Point Server (PEP Server) ensures the
+integrity and consistency of the authorization requests received
+from the PEP clients. Lightweight PEP client libraries are also
+provided to ease the integration and interoperability with other
+EMI services or components.
+
+%prep
+
+%build
+
+%install
+
+%clean
+
+%files
+
+%changelog
+* Fri Apr 15 2016 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0
+- Argus metapackage for EL7.
+
+* Wed Nov 14 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1
+- Argus metapackage for EMI-3.
+

--- a/rpm/metapackage/argus-authz.spec
+++ b/rpm/metapackage/argus-authz.spec
@@ -1,15 +1,22 @@
+%global base_version 1.7.0
+%global base_release 0
+
+%if %{?build_number:1}%{!?build_number:0}
+%define release_version 0.build.%{build_number}
+%else
+%define release_version %{base_release}
+%endif
+
 Name: argus-authz
 
-Version: @@SPEC_VERSION@@
-Release: @@SPEC_RELEASE@@%{?dist}
+Version: %{base_version}
+Release: %{release_version}%{?dist}
 Summary: Argus Authorization Service meta-package (PAP, PDP and PEP Server)
 
 Group: System Environment/Daemons
 License: ASL 2.0
-URL: https://twiki.cern.ch/twiki/bin/view/EGEE/AuthorizationFramework
+URL: http://argus-authz.github.io/
 
-#Source:
-#BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
 
 Requires: argus-pap

--- a/rpm/metapackage/argus-authz.spec
+++ b/rpm/metapackage/argus-authz.spec
@@ -25,6 +25,7 @@ Requires: argus-pep-server
 Requires: argus-pepcli
 Requires: bdii
 Requires: lcg-expiregridmapdir
+Requires: fetch-crl
 
 %description
 Argus meta-package (PAP, PDP and PEP Server).

--- a/rpm/metapackage/build-env
+++ b/rpm/metapackage/build-env
@@ -1,6 +1,6 @@
 BUILD_NAME=argus-metapackage
-BUILD_REPO=/tmp/local_repo/argus-metapackage/.git
-BUILD_TAG=issue/issue-1
+BUILD_REPO=git://github.com/argus-authz/argus-metapackage.git
+BUILD_TAG=master
 PKG_REPO=git://github.com/argus-authz/pkg.argus.git
 PKG_TAG=master
 PKG_SPEC_FILE=argus-metapackage/rpm/metapackage/argus-authz.spec

--- a/rpm/metapackage/build-env
+++ b/rpm/metapackage/build-env
@@ -1,0 +1,6 @@
+BUILD_NAME=argus-metapackage
+BUILD_REPO=/tmp/local_repo/argus-metapackage/.git
+BUILD_TAG=issue/issue-1
+PKG_REPO=git://github.com/argus-authz/pkg.argus.git
+PKG_TAG=master
+PKG_SPEC_FILE=argus-metapackage/rpm/metapackage/argus-authz.spec


### PR DESCRIPTION
Add metapackage  for simplify Argus installation in a single host deployment.
Add metapackage spec file, env file and add the new component in build list.
